### PR TITLE
Add voice-based interview demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# interviewagent
+# Interview Agent
+
+This repository contains a simple example of using the [ElevenLabs](https://elevenlabs.io/) API to ask interview questions with a synthetic voice. The user replies using their microphone and the script transcribes the answer using `SpeechRecognition`.
+
+## Requirements
+
+- Python 3.11+
+- `ffmpeg` installed (for audio playback using `ffplay`). On macOS you can install it with Homebrew:
+  ```bash
+  brew install ffmpeg
+  ```
+- `portaudio` to record from the microphone (install with `brew install portaudio` on macOS).
+- An ElevenLabs API key set in the environment variable `ELEVEN_API_KEY`.
+
+Install Python dependencies:
+
+```bash
+pip install elevenlabs==1.0.4 SpeechRecognition pyaudio
+```
+
+## Running
+
+Execute the script and follow the prompts:
+
+```bash
+python interview_agent.py
+```
+
+The agent will ask a series of interview questions out loud. After each question, speak your answer into the microphone. The script will print the recognized text on the console.

--- a/interview_agent.py
+++ b/interview_agent.py
@@ -1,0 +1,42 @@
+import os
+import speech_recognition as sr
+from elevenlabs import ElevenLabs, play
+
+QUESTIONS = [
+    "What is your name?",
+    "Can you tell me about yourself?",
+    "Why do you want to work here?",
+    "Describe a challenging situation you solved.",
+    "Where do you see yourself in five years?",
+]
+
+
+def ask_question(client: ElevenLabs, question: str) -> str:
+    print(f"Agent: {question}")
+    audio_stream = client.generate(text=question)
+    play(audio_stream)
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        print("Your answer (speak now)...")
+        audio_data = recognizer.listen(source)
+    try:
+        answer = recognizer.recognize_google(audio_data)
+        print(f"You: {answer}")
+    except sr.UnknownValueError:
+        answer = ""
+        print("Sorry, I could not understand your response.")
+    return answer
+
+
+def run_interview():
+    client = ElevenLabs(api_key=os.environ.get("ELEVEN_API_KEY"))
+    responses = []
+    for q in QUESTIONS:
+        responses.append(ask_question(client, q))
+    print("Interview finished. Your answers:")
+    for q, a in zip(QUESTIONS, responses):
+        print(f"Q: {q}\nA: {a}\n")
+
+
+if __name__ == "__main__":
+    run_interview()


### PR DESCRIPTION
## Summary
- implement `interview_agent.py` example
- document how to run the script and required dependencies

## Testing
- `python -m py_compile interview_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6847fa5af6788321b6a7c7847ee9f30d